### PR TITLE
WIP WebRTC transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ node_modules
 
 # local playground
 sandbox
+
+# Example artifacts
+index.browser.js
+node1
+node2

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ dht.on('connect', function() {
 ## Transports
 
 By default, Kad uses UDP to facilitate communication between nodes, however it
-is possible to use a different transport. Kad ships with support for *both* 
-UDP and TCP transports. To explicitly define the transport to use, set the 
+is possible to use a different transport.
+Kad ships with support for UDP, TCP, and WebRTC transports.
+To explicitly define the transport to use, set the
 `transport` option to the appropriate value.
 
 ```js
@@ -59,6 +60,10 @@ var dht = kademlia({
 ```
 
 Implementing other transports should be possible. Pull requests welcome!
+
+You can see examples of the WebRTC transport in the
+[examples](https://github.com/gordonwritescode/kad/tree/master/examples)
+directory.
 
 ## Persistence
 
@@ -96,7 +101,6 @@ nat.portMapping({
   });
 });
 ```
-
 
 ## License
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,6 @@
+Examples
+========
+
+This directory contains examples of running kad.
+
+To build them, run `npm run build-examples`.

--- a/examples/webrtc-browser-e2e/README.md
+++ b/examples/webrtc-browser-e2e/README.md
@@ -1,0 +1,25 @@
+webrtc-browser-e2e
+==================
+
+A signal server is needed to perform a WebRTC handshake
+and initiate the peer-to-peer connection.
+This example demonstrates end-to-end connectivity with a signal server.
+
+## Running the example
+
+To start the signal server, do
+
+    node examples/webrtc-browser-e2e/server.js
+
+Then, in your browser navigate to
+
+    http://localhost:8080/examples/webrtc-browser-e2e/index.html
+
+## Explanation
+
+This will start two nodes which will use the signal server to
+initiate a peer-to-peer connection.
+
+These two nodes could sit in different browsers on different computers.
+
+For simplicity's sake, the code runs in a single browser session.

--- a/examples/webrtc-browser-e2e/index.html
+++ b/examples/webrtc-browser-e2e/index.html
@@ -1,0 +1,1 @@
+<!doctype html><script src="index.browser.js"></script>

--- a/examples/webrtc-browser-e2e/index.js
+++ b/examples/webrtc-browser-e2e/index.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var kademlia = require('../..');
+var KadLocalStorage = require('kad-localstorage');
+var webSocket = require('./web-socket');
+var SignalClient = require('./signal-client');
+var EventEmitter = require('events').EventEmitter;
+var signalClient1 = new SignalClient('node1');
+var signalClient2 = new SignalClient('node2');
+
+webSocket.on('open', function() {
+
+  // Create our first node
+  var node1 = kademlia({
+    transport: kademlia.transports.WebRTC,
+    nick: 'node1',
+    signaller: signalClient1,
+    storage: new KadLocalStorage('node1')
+  });
+
+  // Create a second node
+  var node2 = kademlia({
+    transport: kademlia.transports.WebRTC,
+    nick: 'node2',
+    signaller: signalClient2,
+    storage: new KadLocalStorage('node2'),
+    seeds: [{ nick: 'node1' }] // Connect to the first node
+  });
+
+  node2.on('connect', onConnect);
+
+  function onConnect() {
+    node1.put('beep', 'boop', onPut);
+  }
+
+  function onPut(err) {
+    node2.get('beep', onGet);
+  }
+
+  function onGet(err, value) {
+    alert(value); // 'boop'
+  }
+
+});

--- a/examples/webrtc-browser-e2e/server.js
+++ b/examples/webrtc-browser-e2e/server.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var http = require('http');
+var path = require('path');
+var fs = require('fs');
+var EventEmitter = require('events').EventEmitter;
+var signaller = new EventEmitter();
+var WebSocketServer = require('ws').Server;
+var port = 8080;
+var server = require('http').createServer().listen(port);
+var ws = new WebSocketServer({ server: server });
+
+ws.on('connection', function(connection) {
+
+  console.log('WebSocketServer connection');
+
+  connection.on('message', function(data) {
+
+    console.log()
+    console.log('websocket message', new Date(), data);
+
+    var parsed = JSON.parse(data);
+    if(parsed.recipient && parsed.message) {
+      return signaller.emit(parsed.recipient, parsed.message);
+    }
+
+    signaller.on(parsed.announceNick, function(message) {
+      var json = JSON.stringify(message);
+      console.log('websocket sending', json, 'to', parsed.announceNick);
+      connection.send(json);
+    });
+
+    connection.on('close', function() {
+      signaller.removeAllListeners(parsed.announceNick);
+    });
+  });
+});
+
+server.on('request', function(req, res) {
+  var filePath = __dirname + '/../..' + req.url;
+  fs.readFile(filePath, function(err, file) {
+    if(err) {
+      var message = 'invalid file: ' + filePath;
+      console.log(message);
+      res.statusCode = 404;
+      return res.end(message);
+    }
+    var extension = path.extname(filePath).substring(1);
+    console.log('serving', filePath);
+    res.statusCode = 200;
+    res.setHeader('Content-Type', 'text/' + extension);
+    res.setHeader('Content-Length', file.length);
+    res.end(file);
+  });
+});
+
+console.log('listening on port', port);

--- a/examples/webrtc-browser-e2e/signal-client.js
+++ b/examples/webrtc-browser-e2e/signal-client.js
@@ -1,0 +1,42 @@
+/**
+* @module kad/examples/webrtc-browser-e2e/SignalClient
+*/
+
+'use strict';
+
+var EventEmitter = require('events').EventEmitter;
+var webSocket = require('./web-socket');
+var inherits = require('util').inherits;
+
+inherits(SignalClient, EventEmitter);
+
+/**
+* A client for talking to the signal server.
+* @param {string} nick
+* @constructor
+*/
+function SignalClient(nick) {
+  var signalClient = this;
+
+  webSocket.on('open', function() {
+    webSocket.send(JSON.stringify({ announceNick: nick }));
+  });
+
+  webSocket.on('message', function(message) {
+    var parsed = JSON.parse(message);
+    if(nick !== parsed.sender) {
+      EventEmitter.prototype.emit.call(signalClient, nick, parsed);
+    }
+  });
+}
+
+/**
+* Send a signal to the signal server to perform a WebRTC handshake
+* @param {string} recipient
+* @param {string} message
+*/
+SignalClient.prototype.emit = function(recipient, message) {
+  webSocket.send(JSON.stringify({ recipient: recipient, message: message }));
+};
+
+module.exports = SignalClient;

--- a/examples/webrtc-browser-e2e/web-socket.js
+++ b/examples/webrtc-browser-e2e/web-socket.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var EventEmitter = require('events').EventEmitter;
+var emitter = new EventEmitter();
+var socket = new WebSocket('ws://localhost:8080');
+
+/**
+* Handle socket errors
+* @param {object} error
+* @param {function} callback
+*/
+socket.onerror = function(error) {
+  console.log('onerror', error);
+};
+
+/**
+* Handle socket close
+*/
+socket.onclose = function() {
+  console.log('onclose');
+};
+
+/**
+* Handle socket open and propagate the event
+*/
+socket.onopen = function() {
+  emitter.emit('open');
+};
+
+/**
+* Handle socket message and propagate the event
+*/
+socket.onmessage = function(message) {
+  emitter.emit('message', message.data);
+};
+
+/**
+* Send the message over the socket
+* @param {string} message
+*/
+emitter.send = function(message) {
+  socket.send(message);
+};
+
+module.exports = emitter;

--- a/examples/webrtc-browser/README.md
+++ b/examples/webrtc-browser/README.md
@@ -1,0 +1,19 @@
+webrtc-browser
+====================
+
+This example demonstrates using the WebRTC transport in the browser.
+
+For simplicity's sake a signal server is omitted.
+To see an end-to-end example with a signal server,
+check out the `webrtc-browser-e2e` example.
+
+## Running the example
+
+Start a static server, for example with
+[http-server](https://github.com/indexzero/http-server):
+
+    http-server -c-1
+
+Then, in your browser navigate to
+
+    http://localhost:8080/examples/webrtc-browser/index.html

--- a/examples/webrtc-browser/index.html
+++ b/examples/webrtc-browser/index.html
@@ -1,0 +1,1 @@
+<!doctype html><script src="index.browser.js"></script>

--- a/examples/webrtc-browser/index.js
+++ b/examples/webrtc-browser/index.js
@@ -1,0 +1,39 @@
+'use strict';
+
+var kademlia = require('../..');
+var KadLocalStorage = require('kad-localstorage');
+var EventEmitter = require('events').EventEmitter;
+
+// The two nodes share a signaller
+var signaller = new EventEmitter();
+
+// Create our first node
+var node1 = kademlia({
+  transport: kademlia.transports.WebRTC,
+  nick: 'node1',
+  signaller: signaller,
+  storage: new KadLocalStorage('node1')
+});
+
+// Create a second node
+var node2 = kademlia({
+  transport: kademlia.transports.WebRTC,
+  nick: 'node2',
+  signaller: signaller,
+  storage: new KadLocalStorage('node2'),
+  seeds: [{ nick: 'node1' }] // Connect to the first node
+});
+
+node2.on('connect', onConnect);
+
+function onConnect() {
+  node1.put('beep', 'boop', onPut);
+}
+
+function onPut(err) {
+  node2.get('beep', onGet);
+}
+
+function onGet(err, value) {
+  alert(value); // 'boop'
+}

--- a/examples/webrtc-node/README.md
+++ b/examples/webrtc-node/README.md
@@ -1,0 +1,17 @@
+webrtc-node
+===========
+
+The WebRTC transport can be run directly from Node.
+To do so, you must pass the `wrtc` package during initialization.
+
+A signal server is needed to perform a WebRTC handshake
+and initiate the peer-to-peer connection.
+For this example, we just use an `EventEmitter` in place of a signal server.
+For an end-to-end example of a signal server,
+checkout the `webrtc-browser-e2e` example.
+
+## Running the example
+
+Just do
+
+    node examples/webrtc-node/index.js

--- a/examples/webrtc-node/index.js
+++ b/examples/webrtc-node/index.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var kademlia = require('../..');
+var levelup = require('levelup');
+var EventEmitter = require('events').EventEmitter;
+var wrtc = require('wrtc');
+
+// The two nodes share a signaller
+var signaller = new EventEmitter();
+
+// Create our first node
+var node1 = kademlia({
+  transport: kademlia.transports.WebRTC,
+  nick: 'node1',
+  signaller: signaller,
+  storage: levelup('node1'),
+  wrtc: wrtc // When running in Node, we have to pass the wrtc package
+});
+
+// Create a second node
+var node2 = kademlia({
+  transport: kademlia.transports.WebRTC,
+  nick: 'node2',
+  signaller: signaller,
+  storage: levelup('node2'),
+  seeds: [{ nick: 'node1' }], // Connect to the first node
+  wrtc: wrtc // When running in Node, we have to pass the wrtc package
+});
+
+node2.on('connect', onNode2Ready);
+
+function onNode2Ready() {
+  node1.put('beep', 'boop', onPut);
+}
+
+function onPut(err) {
+  node2.get('beep', onGet);
+}
+
+function onGet(err, value) {
+  console.log(value); // 'boop'
+}

--- a/index.js
+++ b/index.js
@@ -23,9 +23,6 @@ module.exports = function createNode(options, onConnect) {
 
   for (var i = 0; i < options.seeds.length; i++) {
     var seed = options.seeds[i];
-
-    assert(typeof seed.address === 'string', 'Invalid seed address');
-    assert(typeof seed.port === 'number', 'Invalid seed port');
   }
 
   var node = new Node(options);
@@ -33,7 +30,7 @@ module.exports = function createNode(options, onConnect) {
   async.eachSeries(options.seeds, connectToSeed, onConnect);
 
   function connectToSeed(seed, done) {
-    node.connect(seed.address, seed.port, done);
+    node.connect(seed, done);
   }
 
   return node;

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -24,7 +24,7 @@ module.exports = {
   // T_EXPIRE is 5s higher than protocol spec to avoid republish race condition
   T_EXPIRE: ms('86405s'),
 
-  T_RESPONSETIMEOUT: ms('2s'),
+  T_RESPONSETIMEOUT: ms('100s'),
 
   MESSAGE_TYPES: [
     'PING',

--- a/lib/contact.js
+++ b/lib/contact.js
@@ -6,28 +6,19 @@
 
 var assert = require('assert');
 var utils = require('./utils');
-var constants = require('./constants');
 
 /**
 * Represent a contact (or peer)
 * @constructor
-* @param {string} address
-* @param {number} port
-* @param {string} nodeID
+* @param {object} options
 */
-function Contact(address, port, nodeID) {
-  if (!(this instanceof Contact)) {
-    return new Contact(address, port, nodeID);
-  }
+function Contact(options) {
 
-  assert(typeof address === 'string', 'Invalid address was supplied');
-  assert(typeof port === 'number', 'Invalid port was supplied');
-
-  this.address = address;
-  this.port = port;
+  assert(this instanceof Contact, 'Invalid instance was supplied');
+  assert(options instanceof Object, 'Invalid options were supplied');
 
   Object.defineProperty(this, 'nodeID', {
-    value: nodeID || this._createNodeID(),
+    value: options.nodeID || this._createNodeID(),
     configurable: false,
     enumerable: true
   });
@@ -45,12 +36,13 @@ Contact.prototype.seen = function() {
   this.lastSeen = Date.now();
 };
 
+/* istanbul ignore next */
 /**
-* Generate a NodeID by taking the SHA1 hash of the address and port
+* Unimplemented stub, called when no nodeID is passed to constructor.
 * #_createNodeID
 */
 Contact.prototype._createNodeID = function() {
-  return utils.createID(this.address + ':' + this.port);
+  throw new Error('Method not implemented');
 };
 
 module.exports = Contact;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -53,7 +53,7 @@ Logger.prototype._bindLogTypes = function() {
 
         args[0] = prefix + ' ' + args[0];
 
-        console.log.apply(null, args);
+        console.log.apply(console, args);
       }
     }
   });

--- a/lib/node.js
+++ b/lib/node.js
@@ -51,14 +51,10 @@ function Node(options) {
     'Store has no `createReadStream` method'
   );
 
-  this._self = Object.freeze(
-    new Contact(options.address, options.port, options.nodeID)
-  );
   this._buckets = {};
   this._log = new Logger(options.logLevel);
-  this._rpc = new this._options.transport(this._self, {
-    logLevel: options.logLevel
-  });
+  this._rpc = new this._options.transport(options);
+  this._self = this._rpc._contact;
 
   this._bindRPCMessageHandlers();
   this._startReplicationInterval();
@@ -70,18 +66,17 @@ function Node(options) {
 /**
 * Connects to the overlay network
 * #connect
-* @param {string} address
-* @param {number} port
+* @param {string} options transport-specific contact options
 * @param {function} callback - optional
 */
-Node.prototype.connect = function(address, port, callback) {
+Node.prototype.connect = function(options, callback) {
   if (callback) {
     this.once('connect', callback);
     this.once('error', callback);
   }
 
   var self = this;
-  var seed = new Contact(address, port);
+  var seed = this._rpc._createContact(options);
 
   this._log.debug('entering overlay network via %j', seed);
 
@@ -152,6 +147,8 @@ Node.prototype.put = function(key, value, options, callback) {
 * @param {function} callback
 */
 Node.prototype.get = function(key, options, callback) {
+  var self = this;
+
   if (typeof options === 'function') {
     callback = options;
   }
@@ -161,12 +158,20 @@ Node.prototype.get = function(key, options, callback) {
   }
 
   this._log.debug('attempting to get value for key %s', key);
-  this._findValue(key, function(err, item) {
-    if (err) {
-      return callback(err);
+
+  this._storage.get(key, function(err, value) {
+    if (!err && value) {
+      return callback(null, JSON.parse(value).value);
     }
 
-    callback(null, JSON.parse(item).value);
+    self._findValue(key, function(err, item) {
+      if (err) {
+        return callback(err);
+      }
+
+      callback(null, JSON.parse(item).value);
+    });
+
   });
 };
 
@@ -184,7 +189,7 @@ Node.prototype._bindRPCMessageHandlers = function() {
   this._rpc.on('CONTACT_SEEN', this._updateContact.bind(this));
 
   this._rpc.on('ready', function() {
-    self._log.debug('node listening on %j', self._rpc._socket.address());
+    self._log.debug('node listening on %j', self._self.toString());
   });
 };
 
@@ -437,7 +442,7 @@ Node.prototype._updateContact = function(contact, callback) {
 * @param {object} params
 */
 Node.prototype._handlePing = function(params) {
-  var contact = new Contact(params.address, params.port, params.nodeID);
+  var contact = this._rpc._createContact(params);
   var message = new Message('PONG', { referenceID: params.rpcID }, this._self);
 
   this._log.info('received PING from %s, sending PONG', params.nodeID);
@@ -462,7 +467,7 @@ Node.prototype._handleStore = function(params) {
   this._log.info('received valid STORE from %s', params.nodeID);
 
   this._storage.put(item.key, JSON.stringify(item), function(err) {
-    var contact = new Contact(params.address, params.port, params.nodeID);
+    var contact = node._rpc._createContact(params);
     var message = new Message('STORE_REPLY', {
       referenceID: params.rpcID,
       success: !!err
@@ -482,7 +487,7 @@ Node.prototype._handleFindNode = function(params) {
   this._log.info('received FIND_NODE from %j', params);
 
   var hasValidKey = utils.isValidKey(params.key);
-  var contact = new Contact(params.address, params.port, params.nodeID);
+  var contact = this._rpc._createContact(params);
   var near = this._getNearestContacts(params.key, constants.K, params.nodeID);
   var message = new Message('FIND_NODE_REPLY', {
     referenceID: params.rpcID,
@@ -501,7 +506,7 @@ Node.prototype._handleFindNode = function(params) {
 Node.prototype._handleFindValue = function(params) {
   var node = this;
   var hasValidKey = utils.isValidKey(params.key);
-  var contact = new Contact(params.address, params.port, params.nodeID);
+  var contact = this._rpc._createContact(params);
   var limit = constants.K;
 
   if (!hasValidKey) {

--- a/lib/router.js
+++ b/lib/router.js
@@ -86,8 +86,7 @@ Router.prototype._iterativeFind = function(contacts, callback) {
 */
 Router.prototype._queryContact = function(contactInfo, callback) {
   var self = this;
-  var info = contactInfo;
-  var contact = new Contact(info.address, info.port, info.nodeID);
+  var contact = this.node._rpc._createContact(contactInfo);
 
   this.node._rpc.send(contact, this.message, function(err, params) {
     if (err) {

--- a/lib/rpc.js
+++ b/lib/rpc.js
@@ -20,21 +20,19 @@ inherits(RPC, events.EventEmitter);
 /**
 * Represents an RPC interface
 * @constructor
-* @param {object} contact
+* @param {object} options
 */
-function RPC(contact, options) {
-  if (!(this instanceof RPC)) {
-    return new RPC(contact, options);
-  }
+function RPC(options) {
+
+  assert(this instanceof RPC, 'Invalid instance supplied');
 
   var self = this;
 
-  assert(contact instanceof Contact, 'Invalid contact supplied');
   events.EventEmitter.call(this);
 
   this._createMessageID = hat.rack(constants.B);
   this._pendingCalls = {};
-  this._contact = contact;
+  this._contact = this._createContact(options);
   this._log = new Logger(options ? options.logLevel : 0);
 
   setInterval(this._expireCalls.bind(this), constants.T_RESPONSETIMEOUT + 5);
@@ -58,7 +56,7 @@ RPC.prototype.send = function(contact, message, callback) {
   var data = message.serialize();
   var offset = 0;
 
-  this._send(data, contact.port, contact.address);
+  this._send(data, contact);
 
   if (typeof callback === 'function') {
     this._pendingCalls[message.params.rpcID] = {
@@ -91,7 +89,7 @@ RPC.prototype._handleMessage = function(buffer, info) {
   try {
     data = JSON.parse(buffer.toString('utf8'));
     params = data.params;
-    contact = new Contact(params.address, params.port, params.nodeID);
+    contact = this._createContact(params);
     message = new Message(data.type, params, contact);
     this._log.debug('received valid message %j', message);
   } catch(err) {
@@ -126,6 +124,7 @@ RPC.prototype._expireCalls = function() {
   }
 };
 
+/* istanbul ignore next */
 /**
 * Unimplemented stub, called on close()
 * #_close
@@ -134,14 +133,24 @@ RPC.prototype._close = function() {
   throw new Error('Method not implemented');
 };
 
+/* istanbul ignore next */
 /**
 * Unimplemented stub, called on send()
 * #_send
 * @param {buffer} data
-* @param {number} port
-* @param {string} address
+* @param {Contact} contact
 */
-RPC.prototype._send = function(data, port, address) {
+RPC.prototype._send = function(data, contact) {
+  throw new Error('Method not implemented');
+};
+
+/* istanbul ignore next */
+/**
+* Unimplemented stub, called in RPC()
+* #_createContact
+* @param {object} options
+*/
+RPC.prototype._createContact = function(options) {
   throw new Error('Method not implemented');
 };
 

--- a/lib/transports/address-port-contact.js
+++ b/lib/transports/address-port-contact.js
@@ -1,0 +1,51 @@
+/**
+* @module kad/contact
+*/
+
+'use strict';
+
+var assert = require('assert');
+var Contact = require('../contact');
+var inherits = require('util').inherits;
+var utils = require('../utils');
+
+inherits(AddressPortContact, Contact);
+
+/**
+* Represent a contact (or peer)
+* @constructor
+* @param {object} options
+*/
+function AddressPortContact(options) {
+
+  if (!(this instanceof AddressPortContact)) {
+    return new AddressPortContact(options);
+  }
+
+  assert(options instanceof Object, 'Invalid options were supplied');
+  assert(typeof options.address === 'string', 'Invalid address was supplied');
+  assert(typeof options.port === 'number', 'Invalid port was supplied');
+
+  this.address = options.address;
+  this.port = options.port;
+
+  Contact.call(this, options)
+}
+
+/**
+* Generate a NodeID by taking the SHA1 hash of the address and port
+* #_createNodeID
+*/
+AddressPortContact.prototype._createNodeID = function() {
+  return utils.createID(this.toString());
+};
+
+/**
+* Generate a user-friendly string for the contact
+* #_toString
+*/
+AddressPortContact.prototype.toString = function() {
+  return this.address + ':' + this.port;
+};
+
+module.exports = AddressPortContact;

--- a/lib/transports/index.js
+++ b/lib/transports/index.js
@@ -6,5 +6,6 @@
 
 module.exports = {
   TCP: require('./tcp'),
-  UDP: require('./udp')
+  UDP: require('./udp'),
+  WebRTC: require('./webrtc')
 };

--- a/lib/transports/tcp.js
+++ b/lib/transports/tcp.js
@@ -7,6 +7,7 @@
 var inherits = require('util').inherits;
 var clarinet = require('clarinet');
 var net = require('net');
+var AddressPortContact = require('./address-port-contact');
 var Message = require('../message');
 var RPC = require('../rpc');
 var utils = require('../utils');
@@ -16,20 +17,21 @@ inherits(TCPTransport, RPC);
 /**
 * Represents an RPC interface over TCP
 * @constructor
-* @param {object} contact
+* @param {object} options
 */
-function TCPTransport(contact, options) {
+function TCPTransport(options) {
   if (!(this instanceof TCPTransport)) {
-    return new TCPTransport(contact, options);
+    return new TCPTransport(options);
   }
 
   var self = this;
 
-  RPC.call(this, contact, options);
+  RPC.call(this, options);
 
   this._socket = net.createServer(this._handleConnection.bind(this));
 
   this._socket.on('error', function(err) {
+    var contact = self._contact;
     self._log.warn('failed to bind to supplied address %s', contact.address);
     self._log.info('binding to all interfaces as a fallback');
     self._socket.close();
@@ -43,19 +45,27 @@ function TCPTransport(contact, options) {
     self.emit('ready');
   });
 
-  this._socket.listen(contact.port, contact.address);
+  this._socket.listen(this._contact.port, this._contact.address);
 }
+
+/**
+* Create a TCP Contact
+* #_createContact
+* @param {object} options
+*/
+TCPTransport.prototype._createContact = function(options) {
+  return new AddressPortContact(options);
+};
 
 /**
 * Send a RPC to the given contact
 * #_send
 * @param {buffer} data
-* @param {number} port
-* @param {string} address
+* @param {Contact} contact
 */
-TCPTransport.prototype._send = function(data, port, address) {
+TCPTransport.prototype._send = function(data, contact) {
   var self = this;
-  var sock = net.createConnection(port, address);
+  var sock = net.createConnection(contact.port, contact.address);
 
   sock.on('error', function(err) {
     self._log.error('error connecting to peer', err);
@@ -70,12 +80,6 @@ TCPTransport.prototype._send = function(data, port, address) {
 */
 TCPTransport.prototype._close = function() {
   this._socket.close();
-
-  for (var contact in this._connections) {
-    this._connections[contact].destroy();
-  }
-
-  this._connections = {};
 };
 
 /**

--- a/lib/transports/udp.js
+++ b/lib/transports/udp.js
@@ -4,6 +4,7 @@
 
 'use strict';
 
+var AddressPortContact = require('./address-port-contact');
 var inherits = require('util').inherits;
 var dgram = require('dgram');
 var RPC = require('../rpc');
@@ -13,22 +14,23 @@ inherits(UDPTransport, RPC);
 /**
 * Represents an UDP transport for RPC
 * @constructor
-* @param {object} contact
+* @param {object} options
 */
-function UDPTransport(contact, options) {
+function UDPTransport(options) {
   if (!(this instanceof UDPTransport)) {
-    return new UDPTransport(contact, options);
+    return new UDPTransport(options);
   }
 
   var self = this;
   var socketOptions = { type: 'udp4', reuseAddr: true };
   var socketMessageHandler = this._handleMessage.bind(this);
 
-  RPC.call(this, contact, options);
+  RPC.call(this, options);
 
   this._socket = dgram.createSocket(socketOptions, socketMessageHandler);
 
   this._socket.on('error', function(err) {
+    var contact = self._contact;
     self._log.warn('failed to bind to supplied address %s', contact.address);
     self._log.info('binding to all interfaces as a fallback');
     self._socket.close();
@@ -42,18 +44,26 @@ function UDPTransport(contact, options) {
     self.emit('ready');
   });
 
-  this._socket.bind(contact.port, contact.address);
+  this._socket.bind(this._contact.port, this._contact.address);
+}
+
+/**
+* Create a UDP Contact
+* #_createContact
+* @param {object} options
+*/
+UDPTransport.prototype._createContact = function(options) {
+  return new AddressPortContact(options);
 }
 
 /**
 * Send a RPC to the given contact
 * #_send
 * @param {buffer} data
-* @param {number} port
-* @param {string} address
+* @param {Contact} contact
 */
-UDPTransport.prototype._send = function(data, port, address) {
-  this._socket.send(data, 0, data.length, port, address);
+UDPTransport.prototype._send = function(data, contact) {
+  this._socket.send(data, 0, data.length, contact.port, contact.address);
 };
 
 /**

--- a/lib/transports/webrtc-contact.js
+++ b/lib/transports/webrtc-contact.js
@@ -1,0 +1,48 @@
+/**
+* @module kad/peer-contact
+*/
+
+'use strict';
+
+var assert = require('assert');
+var Contact = require('../contact.js');
+var inherits = require('util').inherits;
+var utils = require('../utils');
+
+inherits(WebRTCContact, Contact);
+
+/**
+* Represent a WebRTC contact
+* @constructor
+* @param {object} options
+*/
+function WebRTCContact(options) {
+  if (!(this instanceof WebRTCContact)) {
+    return new WebRTCContact(options);
+  }
+
+  assert(options instanceof Object, 'Invalid options were supplied');
+  assert(typeof options.nick === 'string', 'Invalid nick was supplied');
+
+  this.nick = options.nick;
+
+  Contact.call(this, options);
+}
+
+/**
+* Generate a NodeID by taking the SHA1 hash of the nickname
+* #_createNodeID
+*/
+WebRTCContact.prototype._createNodeID = function() {
+  return utils.createID(this.nick);
+};
+
+/**
+* Generate a user-friendly string for the contact
+* #_toString
+*/
+WebRTCContact.prototype.toString = function() {
+  return this.nick;
+};
+
+module.exports = WebRTCContact;

--- a/lib/transports/webrtc.js
+++ b/lib/transports/webrtc.js
@@ -1,0 +1,132 @@
+/**
+* @module kad/transports/webrtc
+*/
+
+'use strict';
+
+var assert = require('assert');
+var hat = require('hat');
+var inherits = require('util').inherits;
+var WebRTCContact = require('./webrtc-contact');
+var RPC = require('../rpc');
+var SimplePeer = require('simple-peer');
+
+inherits(WebRTCTransport, RPC);
+
+/**
+* Represents an RPC interface over WebRTC
+* @constructor
+* @param {object} options
+*/
+function WebRTCTransport(options) {
+  if (!(this instanceof WebRTCTransport)) {
+    return new WebRTCTransport(options);
+  }
+
+  assert(options instanceof Object, 'Invalid options were supplied');
+  assert(options.signaller instanceof Object, 'Invalid signaller was supplied');
+
+  var self = this
+
+  RPC.call(this, options);
+
+  this._peers = {};
+  this._wrtc = options.wrtc;
+  this._signaller = options.signaller;
+  this._signalHandler = this._onSignal.bind(this);
+  this._signaller.addListener(this._contact.nick, this._signalHandler)
+
+  setTimeout(this.emit.bind(this, 'ready'));
+}
+
+/**
+* Handle a message sent through `_signaller` from another peer
+* #_onSignal
+* @param {object} signallerMessage
+*/
+WebRTCTransport.prototype._onSignal = function(signallerMessage) {
+  var self = this;
+  var signal = signallerMessage.signal;
+  var sender = signallerMessage.sender;
+  var handshakeID = signallerMessage.handshakeID;
+  var peer = this._peers[signallerMessage.handshakeID];
+  if(!peer) {
+    peer = this._createPeer(sender, handshakeID, false);
+    peer.once('data', function(data) {
+      self._handleMessage(data, { nick: signallerMessage.sender });
+    });
+  }
+  peer.signal(signal);
+}
+
+/**
+* Create a WebRTC Contact
+* #_createContact
+* @param {object} options
+*/
+WebRTCTransport.prototype._createContact = function(options) {
+  return new WebRTCContact(options);
+};
+
+/**
+* Send a RPC to the given contact
+* #_send
+* @param {buffer} data
+* @param {Contact} contact
+*/
+WebRTCTransport.prototype._send = function(data, contact) {
+  var self = this;
+  var handshakeID = hat();
+  var newPeer = this._createPeer(contact.nick, handshakeID, true);
+  newPeer.once('connect', function() {
+    newPeer.send(data);
+    setTimeout(function() {
+      newPeer.destroy();
+    });
+  });
+};
+
+/**
+* Initialize a WebRTC peer and store it in `_peers`
+* #_createPeer
+* @param {string} nick
+* @param {string} handshakeID
+* @param {boolean} initiator
+*/
+WebRTCTransport.prototype._createPeer = function(nick, handshakeID, initiator) {
+  var self = this;
+  var peer = new SimplePeer({ wrtc: this._wrtc, initiator: initiator });
+  peer.on('signal', function(signal) {
+    self._signaller.emit(nick, {
+      sender: self._contact.nick,
+      handshakeID: handshakeID,
+      signal: signal
+    });
+  });
+  peer.on('error', function(err) {
+    self._log.error('peer encountered an error %s', err.message);
+  });
+  peer.once('close', function() {
+    peer.removeAllListeners('data');
+    peer.removeAllListeners('signal');
+    peer.removeAllListeners('error');
+    delete self._peers[handshakeID];
+  })
+  this._peers[handshakeID] = peer;
+  return peer;
+}
+
+/**
+* Close the underlying socket
+* #_close
+*/
+WebRTCTransport.prototype._close = function() {
+  var self = this;
+  Object.keys(this._peers).forEach(function(handshakeID) {
+    self._peers[handshakeID].destroy();
+  });
+  this._peers = {};
+  this._signaller.removeListener(this._contact.nick, this._signalHandler);
+};
+
+module.exports = WebRTCTransport;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha test/** --recursive",
-    "coverage": "./node_modules/.bin/istanbul cover -x 'lib/logger.js' ./node_modules/.bin/_mocha -- --recursive"
+    "coverage": "./node_modules/.bin/istanbul cover -x 'lib/logger.js' ./node_modules/.bin/_mocha -- --recursive",
+    "build-webrtc-browser": "./node_modules/.bin/browserify examples/webrtc-browser/index.js > examples/webrtc-browser/index.browser.js",
+    "build-webrtc-browser-e2e": "./node_modules/.bin/browserify examples/webrtc-browser-e2e/index.js > examples/webrtc-browser-e2e/index.browser.js",
+    "build-examples": "npm run build-webrtc-browser && npm run build-webrtc-browser-e2e"
   },
   "keywords": [
     "dht",
@@ -28,14 +31,23 @@
     "hat": "0.0.3",
     "lodash": "^3.6.0",
     "merge": "^1.2.0",
-    "ms": "^0.7.0"
+    "ms": "^0.7.0",
+    "simple-peer": "^5.11.5"
   },
   "devDependencies": {
+    "browserify": "^11.1.0",
     "chai": "^2.2.0",
     "coveralls": "^2.11.2",
     "faker": "^2.1.2",
     "istanbul": "^0.3.13",
     "mocha": "^2.2.4",
     "sinon": "^1.14.1"
+  },
+  "optionalDependencies": {
+    "kad-localstorage": "0.0.4",
+    "leveldown": "^1.4.1",
+    "levelup": "^1.2.1",
+    "wrtc": "0.0.58",
+    "ws": "^0.8.0"
   }
 }

--- a/test/bucket.unit.js
+++ b/test/bucket.unit.js
@@ -2,7 +2,7 @@
 
 var expect = require('chai').expect;
 var Bucket = require('../lib/bucket');
-var Contact = require('../lib/contact');
+var AddressPortContact = require('../lib/transports/address-port-contact');
 
 describe('Bucket', function() {
 
@@ -71,7 +71,7 @@ describe('Bucket', function() {
   describe('#addContact', function() {
 
     var bucket = new Bucket();
-    var contact = new Contact('0.0.0.0', 1337);
+    var contact = new AddressPortContact({ address: '0.0.0.0', port: 1337 });
 
     it('should add the contact to the bucket', function() {
       expect(bucket.getSize()).to.equal(0);
@@ -97,13 +97,15 @@ describe('Bucket', function() {
   describe('#removeContact', function() {
 
     var bucket = new Bucket();
-    bucket.addContact(new Contact('0.0.0.0', 1337));
-    bucket.addContact(new Contact('0.0.0.1', 1337));
-    bucket.addContact(new Contact('0.0.0.2', 1337));
+
+    bucket.addContact(AddressPortContact({ address: '0.0.0.0', port: 1337 }));
+    bucket.addContact(AddressPortContact({ address: '0.0.0.1', port: 1337 }));
+    bucket.addContact(AddressPortContact({ address: '0.0.0.2', port: 1337 }));
 
     it('should remove the given contact', function() {
       expect(bucket.getSize()).to.equal(3);
-      bucket.removeContact(new Contact('0.0.0.0', 1337));
+      var contact = AddressPortContact({ address: '0.0.0.0', port: 1337 });
+      bucket.removeContact(contact);
       expect(bucket.getSize()).to.equal(2);
     });
 
@@ -115,7 +117,8 @@ describe('Bucket', function() {
 
     it('should do nothing if contact is not found', function() {
       expect(bucket.getSize()).to.equal(2);
-      bucket.removeContact(new Contact('0.0.0.3', 1337));
+      var contact = AddressPortContact({ address: '0.0.0.3', port: 1337 })
+      bucket.removeContact(contact);
       expect(bucket.getSize()).to.equal(2);
     });
 
@@ -124,28 +127,34 @@ describe('Bucket', function() {
 
   describe('#hasContact', function() {
 
-    var bucket = Bucket().addContact(new Contact('0.0.0.0', 80));
+    var contact = AddressPortContact({ address: '0.0.0.0', port: 80 });
+    var bucket = Bucket().addContact(contact);
 
     it('should return true because the contact exists', function() {
-      expect(bucket.hasContact(Contact('0.0.0.0', 80).nodeID)).to.equal(true);
+      var otherContact = AddressPortContact({ address: '0.0.0.0', port: 80 });
+      expect(bucket.hasContact(otherContact.nodeID)).to.equal(true);
     });
 
-    it('should return true because the contactdoes not exist', function() {
-      expect(bucket.hasContact(Contact('0.0.0.0', 81).nodeID)).to.equal(false);
+    it('should return true because the contact does not exist', function() {
+      var otherContact = AddressPortContact({ address: '0.0.0.0', port: 81 });
+      expect(bucket.hasContact(otherContact.nodeID)).to.equal(false);
     });
 
   });
 
   describe('#indexOf', function() {
 
-    var bucket = Bucket().addContact(Contact('0.0.0.0', 80));
+    var contact = AddressPortContact({ address: '0.0.0.0', port: 80 });
+    var bucket = Bucket().addContact(contact);
 
     it('should return the index of the given contact object', function() {
-      expect(bucket.indexOf(Contact('0.0.0.0', 80))).to.equal(0);
+      var otherContact = AddressPortContact({ address: '0.0.0.0', port: 80 });
+      expect(bucket.indexOf(otherContact)).to.equal(0);
     });
 
     it('should return -1 for the missing contact object', function() {
-      expect(bucket.indexOf(Contact('0.0.0.0', 81))).to.equal(-1);
+      var otherContact = AddressPortContact({ address: '0.0.0.0', port: 81 });
+      expect(bucket.indexOf(otherContact)).to.equal(-1);
     });
 
   });

--- a/test/message.unit.js
+++ b/test/message.unit.js
@@ -3,13 +3,13 @@
 var expect = require('chai').expect;
 var constants = require('../lib/constants');
 var Message = require('../lib/message');
-var Contact = require('../lib/contact');
+var AddressPortContact = require('../lib/transports/address-port-contact');
 
 describe('Message', function() {
 
   describe('@constructor', function() {
 
-    var contact = new Contact('0.0.0.0', 1337);
+    var contact = new AddressPortContact({ address: '0.0.0.0', port: 1337 });
 
     it('should create an instance with the `new` keyword', function() {
       expect(new Message('PING', {}, contact)).to.be.instanceOf(Message);
@@ -35,7 +35,7 @@ describe('Message', function() {
 
   describe('#serialize', function() {
 
-    var contact = new Contact('0.0.0.0', 1337);
+    var contact = new AddressPortContact({ address: '0.0.0.0', port: 1337 });
 
     it('should return a buffer ready for sending', function() {
       var msg = new Message('PING', {}, contact);

--- a/test/router.unit.js
+++ b/test/router.unit.js
@@ -5,7 +5,7 @@ var sinon = require('sinon');
 var utils = require('../lib/utils');
 var constants = require('../lib/constants');
 var Router = require('../lib/router');
-var Contact = require('../lib/contact');
+var AddressPortContact = require('../lib/transports/address-port-contact');
 var Node = require('../lib/node');
 
 function FakeStorage() {
@@ -44,7 +44,7 @@ describe('Router', function() {
       var _rpc = sinon.stub(router.node._rpc, 'send', function(c, m, d) {
         d(new Error());
       });
-      var contact = new Contact('0.0.0.0', 1234);
+      var contact = new AddressPortContact({ address: '0.0.0.0', port: 1234 });
       router.shortlist.push(contact);
       router._queryContact(contact, function() {
         expect(router.shortlist).to.have.lengthOf(0);
@@ -63,7 +63,7 @@ describe('Router', function() {
         port: 0,
         storage: new FakeStorage()
       }));
-      var contact = new Contact('0.0.0.0', 1234);
+      var contact = new AddressPortContact({ address: '0.0.0.0', port: 1234 });
       router.shortlist.push(contact);
       router.closestNodeDistance = '00000000000000000001';
       router._handleFindResult({
@@ -85,7 +85,7 @@ describe('Router', function() {
         port: 0,
         storage: new FakeStorage()
       }));
-      var contact = new Contact('0.0.0.0', 1234);
+      var contact = new AddressPortContact({ address: '0.0.0.0', port: 1234 });
       router.shortlist = new Array(constants.K);
       router._handleQueryResults(function(err, type, contacts) {
         expect(contacts).to.equal(router.shortlist);
@@ -104,8 +104,8 @@ describe('Router', function() {
         storage: new FakeStorage()
       }));
       var _send = sinon.stub(router.node._rpc, 'send');
-      var contact1 = new Contact('0.0.0.0', 1234);
-      var contact2 = new Contact('0.0.0.0', 1235);
+      var contact1 = new AddressPortContact({ address: '0.0.0.0', port: 1234 });
+      var contact2 = new AddressPortContact({ address: '0.0.0.0', port: 1235 });
       router.contactsWithoutValue = [contact1, contact2];
       router._handleValueReturned(function(err, type, contacts) {
         expect(_send.callCount).to.equal(1);

--- a/test/transports/address-port-contact.unit.js
+++ b/test/transports/address-port-contact.unit.js
@@ -1,0 +1,74 @@
+'use strict';
+
+var expect = require('chai').expect;
+var constants = require('../../lib/constants');
+var crypto = require('crypto');
+var AddressPortContact = require('../../lib/transports/address-port-contact');
+var hat = require('hat');
+
+describe('AddressPortContact', function() {
+
+  describe('@constructor', function() {
+
+    it('should create an instance with the `new` keyword', function() {
+      var c = new AddressPortContact({ address: '0.0.0.0', port: 1337 });
+      expect(c).to.be.instanceOf(AddressPortContact);
+    });
+
+    it('should create an instance without the `new` keyword', function() {
+      var c = AddressPortContact({ address: '0.0.0.0', port: 1337 });
+      expect(c).to.be.instanceOf(AddressPortContact);
+    });
+
+    it('should throw without an address', function() {
+      expect(function() {
+        AddressPortContact({ port: 1337 });
+      }).to.throw(Error, 'Invalid address was supplied');
+    });
+
+    it('should throw without a port', function() {
+      expect(function() {
+        AddressPortContact({ address: '0.0.0.0' });
+      }).to.throw(Error, 'Invalid port was supplied');
+    });
+
+    it('should use the given nodeID instead of generating one', function() {
+      var i = hat(constants.B)
+      var c = AddressPortContact({ address: '0.0.0.0', port: 1337, nodeID: i });
+      expect(c.nodeID).to.equal(i);
+    });
+
+    it('should throw with an invalid supplied nodeID', function() {
+      expect(function() {
+        var i = hat(24)
+        var opts = { address: '0.0.0.0', port: 1337, nodeID: i };
+        var c = AddressPortContact(opts);
+      }).to.throw(Error, 'Invalid nodeID was supplied');
+    });
+
+  });
+
+  describe('#seen', function() {
+
+    it('should update the lastSeen property', function() {
+      var c = AddressPortContact({ address: '0.0.0.0', port: 1337 });
+      var s1 = c.lastSeen;
+      setTimeout(function() {
+        c.seen();
+        expect((c.lastSeen - s1) >= 10).to.equal(true);
+      }, 100);
+    });
+
+  });
+
+  describe('#_createNodeID', function() {
+
+    it('should compute the SHA1 digest of the address and port', function() {
+      var c = AddressPortContact({ address: '0.0.0.0', port: 1337 });
+      var i = crypto.createHash('sha1').update(c.address + ':' + c.port);
+      expect(c._createNodeID()).to.equal(i.digest('hex'));
+    });
+
+  });
+
+});

--- a/test/transports/tcp.unit.js
+++ b/test/transports/tcp.unit.js
@@ -4,7 +4,7 @@ var expect = require('chai').expect;
 var sinon = require('sinon');
 var constants = require('../../lib/constants');
 var RPC = require('../../lib/transports/tcp');
-var Contact = require('../../lib/contact');
+var AddressPortContact = require('../../lib/transports/address-port-contact');
 var Message = require('../../lib/message');
 
 describe('Transports/TCP', function() {
@@ -12,25 +12,19 @@ describe('Transports/TCP', function() {
   describe('@constructor', function() {
 
     it('should create an instance with the `new` keyword', function() {
-      var contact = new Contact('0.0.0.0', 0);
+      var contact = new AddressPortContact({ address: '0.0.0.0', port: 0 });
       var rpc = new RPC(contact);
       expect(rpc).to.be.instanceOf(RPC);
     });
 
     it('should create an instance without the `new` keyword', function() {
-      var contact = new Contact('0.0.0.0', 0);
+      var contact = new AddressPortContact({ address: '0.0.0.0', port: 0 });
       var rpc = RPC(contact);
       expect(rpc).to.be.instanceOf(RPC);
     });
 
-    it('should throw with an invalid contact', function() {
-      expect(function() {
-        RPC({ address: '0.0.0.0', port: 1234 });
-      }).to.throw(Error, 'Invalid contact supplied');
-    });
-
     it('should bind to the given port (or random port)', function(done) {
-      var contact = new Contact('0.0.0.0', 0);
+      var contact = new AddressPortContact({ address: '0.0.0.0', port: 0 });
       var rpc = RPC(contact);
       rpc.on('ready', function() {
         expect(rpc._socket.address().address).to.equal('0.0.0.0');
@@ -41,10 +35,18 @@ describe('Transports/TCP', function() {
 
   });
 
+  describe('#_createContact', function() {
+    it('should create an AddressPortContact', function() {
+      var rpc = new RPC({ address: '0.0.0.0', port: 1 });
+      var contact = rpc._createContact({ address: '0.0.0.0', port: 0 });
+      expect(contact).to.be.instanceOf(AddressPortContact);
+    });
+  });
+
   describe('#send', function() {
 
-    var contact1 = new Contact('0.0.0.0', 0);
-    var contact2 = new Contact('0.0.0.0', 0);
+    var contact1 = new AddressPortContact({ address: '0.0.0.0', port: 0 });
+    var contact2 = new AddressPortContact({ address: '0.0.0.0', port: 0 });
     var rpc1;
     var rpc2;
 
@@ -75,7 +77,7 @@ describe('Transports/TCP', function() {
     });
 
     it('should throw with invalid message', function() {
-      var contact = new Contact('0.0.0.0', 1234);
+      var contact = new AddressPortContact({ address: '0.0.0.0', port: 1234 });
       expect(function() {
         rpc1.send(contact, {});
       }).to.throw(Error, 'Invalid message supplied');
@@ -84,8 +86,8 @@ describe('Transports/TCP', function() {
     it('should send a message and create a response handler', function() {
       var addr1 = rpc1._socket.address();
       var addr2 = rpc2._socket.address();
-      var contactRpc1 = new Contact(addr1.address, addr1.port);
-      var contactRpc2 = new Contact(addr2.address, addr2.port);
+      var contactRpc1 = new AddressPortContact(addr1);
+      var contactRpc2 = new AddressPortContact(addr2);
       var msg = new Message('PING', {}, contactRpc1);
       var handler = sinon.stub();
       rpc1.send(contactRpc2, msg, handler);
@@ -97,8 +99,8 @@ describe('Transports/TCP', function() {
     it('should send a message and forget it', function() {
       var addr1 = rpc1._socket.address();
       var addr2 = rpc2._socket.address();
-      var contactRpc1 = new Contact(addr1.address, addr1.port);
-      var contactRpc2 = new Contact(addr2.address, addr2.port);
+      var contactRpc1 = new AddressPortContact(addr1);
+      var contactRpc2 = new AddressPortContact(addr2);
       var msg = new Message('PING', {}, contactRpc1);
       rpc2.send(contactRpc1, msg);
       var calls = Object.keys(rpc2._pendingCalls);
@@ -110,7 +112,7 @@ describe('Transports/TCP', function() {
   describe('#close', function() {
 
     it('should close the underlying socket', function(done) {
-      var contact = new Contact('0.0.0.0', 0);
+      var contact = new AddressPortContact({ address: '0.0.0.0', port: 0 });
       var rpc = new RPC(contact);
       rpc.on('ready', function() {
         rpc._socket.on('close', done);
@@ -122,8 +124,8 @@ describe('Transports/TCP', function() {
 
   describe('#_handleMessage', function() {
 
-    var contact1 = Contact('0.0.0.0', 1234);
-    var contact2 = Contact('0.0.0.0', 0);
+    var contact1 = new AddressPortContact({ address: '0.0.0.0', port: 1234 });
+    var contact2 = new AddressPortContact({ address: '0.0.0.0', port: 0 });
     var validMsg1 = Message('PING', { rpcID: 10 }, contact1).serialize();
     var validMsg2 = Message('PONG', { referenceID: 10 }, contact1).serialize();
     var invalidMsg = Buffer(JSON.stringify({ type: 'WRONG', params: {} }));
@@ -168,7 +170,7 @@ describe('Transports/TCP', function() {
   describe('#_expireCalls', function() {
 
     it('should call expired handler with error and remove it', function() {
-      var contact = new Contact('0.0.0.0', 0);
+      var contact = new AddressPortContact({ address: '0.0.0.0', port: 0 });
       var rpc = new RPC(contact);
       var freshHandler = sinon.stub();
       var staleHandler = sinon.spy();

--- a/test/transports/udp.unit.js
+++ b/test/transports/udp.unit.js
@@ -4,7 +4,7 @@ var expect = require('chai').expect;
 var sinon = require('sinon');
 var constants = require('../../lib/constants');
 var RPC = require('../../lib/transports/udp');
-var Contact = require('../../lib/contact');
+var AddressPortContact = require('../../lib/transports/address-port-contact');
 var Message = require('../../lib/message');
 
 describe('Transports/UDP', function() {
@@ -12,25 +12,19 @@ describe('Transports/UDP', function() {
   describe('@constructor', function() {
 
     it('should create an instance with the `new` keyword', function() {
-      var contact = new Contact('0.0.0.0', 0);
+      var contact = new AddressPortContact({ address: '0.0.0.0', port: 0 });
       var rpc = new RPC(contact);
       expect(rpc).to.be.instanceOf(RPC);
     });
 
     it('should create an instance without the `new` keyword', function() {
-      var contact = new Contact('0.0.0.0', 0);
+      var contact = new AddressPortContact({ address: '0.0.0.0', port: 0 });
       var rpc = RPC(contact);
       expect(rpc).to.be.instanceOf(RPC);
     });
 
-    it('should throw with an invalid contact', function() {
-      expect(function() {
-        RPC({ address: '0.0.0.0', port: 1234 });
-      }).to.throw(Error, 'Invalid contact supplied');
-    });
-
     it('should bind to the given port (or random port)', function(done) {
-      var contact = new Contact('0.0.0.0', 0);
+      var contact = new AddressPortContact({ address: '0.0.0.0', port: 0 });
       var rpc = RPC(contact);
       rpc.on('ready', function() {
         expect(rpc._socket.address().address).to.equal('0.0.0.0');
@@ -41,10 +35,18 @@ describe('Transports/UDP', function() {
 
   });
 
+  describe('#_createContact', function() {
+    it('should create an AddressPortContact', function() {
+      var rpc = new RPC({ address: '0.0.0.0', port: 1 });
+      var contact = rpc._createContact({ address: '0.0.0.0', port: 0 });
+      expect(contact).to.be.instanceOf(AddressPortContact);
+    });
+  });
+
   describe('#send', function() {
 
-    var contact1 = new Contact('0.0.0.0', 0);
-    var contact2 = new Contact('0.0.0.0', 0);
+    var contact1 = new AddressPortContact({ address: '0.0.0.0', port: 0 });
+    var contact2 = new AddressPortContact({ address: '0.0.0.0', port: 0 });
     var rpc1;
     var rpc2;
 
@@ -75,7 +77,7 @@ describe('Transports/UDP', function() {
     });
 
     it('should throw with invalid message', function() {
-      var contact = new Contact('0.0.0.0', 1234);
+      var contact = new AddressPortContact({ address: '0.0.0.0', port: 1234 });
       expect(function() {
         rpc1.send(contact, {});
       }).to.throw(Error, 'Invalid message supplied');
@@ -84,8 +86,8 @@ describe('Transports/UDP', function() {
     it('should send a message and create a response handler', function() {
       var addr1 = rpc1._socket.address();
       var addr2 = rpc2._socket.address();
-      var contactRpc1 = new Contact(addr1.address, addr1.port);
-      var contactRpc2 = new Contact(addr2.address, addr2.port);
+      var contactRpc1 = new AddressPortContact(addr1);
+      var contactRpc2 = new AddressPortContact(addr2);
       var msg = new Message('PING', {}, contactRpc1);
       var handler = sinon.stub();
       rpc1.send(contactRpc2, msg, handler);
@@ -97,8 +99,8 @@ describe('Transports/UDP', function() {
     it('should send a message and forget it', function() {
       var addr1 = rpc1._socket.address();
       var addr2 = rpc2._socket.address();
-      var contactRpc1 = new Contact(addr1.address, addr1.port);
-      var contactRpc2 = new Contact(addr2.address, addr2.port);
+      var contactRpc1 = new AddressPortContact(addr1);
+      var contactRpc2 = new AddressPortContact(addr2);
       var msg = new Message('PING', {}, contactRpc1);
       rpc2.send(contactRpc1, msg);
       var calls = Object.keys(rpc2._pendingCalls);
@@ -110,7 +112,7 @@ describe('Transports/UDP', function() {
   describe('#close', function() {
 
     it('should close the underlying socket', function(done) {
-      var contact = new Contact('0.0.0.0', 0);
+      var contact = new AddressPortContact({ address: '0.0.0.0', port: 0 });
       var rpc = new RPC(contact);
       rpc.on('ready', function() {
         expect(rpc._socket._receiving).to.equal(true);
@@ -124,8 +126,8 @@ describe('Transports/UDP', function() {
 
   describe('#_handleMessage', function() {
 
-    var contact1 = Contact('0.0.0.0', 1234);
-    var contact2 = Contact('0.0.0.0', 0);
+    var contact1 = new AddressPortContact({ address: '0.0.0.0', port: 1234 });
+    var contact2 = new AddressPortContact({ address: '0.0.0.0', port: 0 });
     var validMsg1 = Message('PING', { rpcID: 10 }, contact1).serialize();
     var validMsg2 = Message('PONG', { referenceID: 10 }, contact1).serialize();
     var invalidMsg = Buffer(JSON.stringify({ type: 'WRONG', params: {} }));
@@ -170,7 +172,7 @@ describe('Transports/UDP', function() {
   describe('#_expireCalls', function() {
 
     it('should call expired handler with error and remove it', function() {
-      var contact = new Contact('0.0.0.0', 0);
+      var contact = new AddressPortContact({ address: '0.0.0.0', port: 0 });
       var rpc = new RPC(contact);
       var freshHandler = sinon.stub();
       var staleHandler = sinon.spy();

--- a/test/transports/webrtc-contact.unit.js
+++ b/test/transports/webrtc-contact.unit.js
@@ -1,45 +1,42 @@
 'use strict';
 
 var expect = require('chai').expect;
-var constants = require('../lib/constants');
+var constants = require('../../lib/constants');
 var crypto = require('crypto');
-var Contact = require('../lib/contact');
+var WebRTCContact = require('../../lib/transports/webrtc-contact');
 var hat = require('hat');
 
-describe('Contact', function() {
+describe('WebRTCContact', function() {
 
   describe('@constructor', function() {
 
     it('should create an instance with the `new` keyword', function() {
-      expect(new Contact('0.0.0.0', 1337)).to.be.instanceOf(Contact);
+      var c = new WebRTCContact({ nick: 'a' });
+      expect(c).to.be.instanceOf(WebRTCContact);
     });
 
     it('should create an instance without the `new` keyword', function() {
-      expect(Contact('0.0.0.0', 1337)).to.be.instanceOf(Contact);
+      var c = WebRTCContact({ nick: 'a' });
+      expect(c).to.be.instanceOf(WebRTCContact);
     });
 
-    it('should throw without an address', function() {
+    it('should throw without a nick', function() {
       expect(function() {
-        Contact(null, 1337);
-      }).to.throw(Error, 'Invalid address was supplied');
-    });
-
-    it('should throw without a port', function() {
-      expect(function() {
-        Contact('0.0.0.0');
-      }).to.throw(Error, 'Invalid port was supplied');
+        WebRTCContact({});
+      }).to.throw(Error, 'Invalid nick was supplied');
     });
 
     it('should use the given nodeID instead of generating one', function() {
       var i = hat(constants.B)
-      var c = Contact('0.0.0.0', 1337, i);
+      var c = WebRTCContact({ nick: 'a', nodeID: i });
       expect(c.nodeID).to.equal(i);
     });
 
     it('should throw with an invalid supplied nodeID', function() {
       expect(function() {
         var i = hat(24)
-        var c = Contact('0.0.0.0', 1337, i);
+        var opts = { nick: 'a', nodeID: i };
+        var c = WebRTCContact(opts);
       }).to.throw(Error, 'Invalid nodeID was supplied');
     });
 
@@ -48,11 +45,11 @@ describe('Contact', function() {
   describe('#seen', function() {
 
     it('should update the lastSeen property', function() {
-      var c = Contact('0.0.0.0', 1337);
-      var s1 = c.lastSeen.toString();
+      var c = WebRTCContact({ nick: 'a' });
+      var s1 = c.lastSeen;
       setTimeout(function() {
         c.seen();
-        expect((c.lastSeen - Number(s1)) >= 10).to.equal(true);
+        expect((c.lastSeen - s1) >= 10).to.equal(true);
       }, 10);
     });
 
@@ -61,8 +58,8 @@ describe('Contact', function() {
   describe('#_createNodeID', function() {
 
     it('should compute the SHA1 digest of the address and port', function() {
-      var c = Contact('0.0.0.0', 1337);
-      var i = crypto.createHash('sha1').update(c.address + ':' + c.port);
+      var c = WebRTCContact({ nick: 'a' });
+      var i = crypto.createHash('sha1').update('a');
       expect(c._createNodeID()).to.equal(i.digest('hex'));
     });
 

--- a/test/transports/webrtc.unit.js
+++ b/test/transports/webrtc.unit.js
@@ -1,0 +1,347 @@
+'use strict';
+
+var expect = require('chai').expect;
+var hat = require('hat');
+var sinon = require('sinon');
+var constants = require('../../lib/constants');
+var RPC = require('../../lib/transports/webrtc');
+var WebRTCContact = require('../../lib/transports/webrtc-contact');
+var Message = require('../../lib/message');
+var wrtc = require('wrtc');
+var transportOptions = { wrtc: wrtc };
+var SimplePeer = require('simple-peer');
+var EventEmitter = require('events').EventEmitter;
+
+describe('Transports/WebRTC', function() {
+
+  describe('@constructor', function() {
+
+    it('should create an instance with the `new` keyword', function() {
+      var signaller = new EventEmitter();
+      var rpc = new RPC({ nick: 'a', wrtc: wrtc, signaller: signaller });
+      expect(rpc).to.be.instanceOf(RPC);
+    });
+
+    it('should create an instance without the `new` keyword', function() {
+      var signaller = new EventEmitter();
+      var rpc = RPC({ nick: 'a', wrtc: wrtc, signaller: signaller });
+      expect(rpc).to.be.instanceOf(RPC);
+    });
+
+    it('should throw without options', function() {
+      expect(function() {
+        RPC(null);
+      }).to.throw(Error, 'Invalid options were supplied');
+    });
+
+    it('should throw without signaller', function() {
+      expect(function() {
+        RPC({ nick: 'a' });
+      }).to.throw(Error, 'Invalid signaller was supplied');
+    });
+
+    it('should bind to the signaller', function() {
+      var signaller = new EventEmitter();
+      var addListener = sinon.stub(signaller, 'addListener');
+      var rpc = new RPC({ nick: 'a', wrtc: wrtc, signaller: signaller });
+      expect(addListener.callCount).to.equal(1);
+      expect(addListener.calledWith('a', rpc._signalHandler)).to.equal(true);
+    });
+
+    it('should emit a ready event', function(done) {
+      var signaller = new EventEmitter();
+      var rpc = new RPC({ nick: 'a', wrtc: wrtc, signaller: signaller });
+      rpc.on('ready', done);
+    });
+  });
+
+  describe('#_onSignal', function() {
+
+    it('should create a new peer', function(done) {
+      var signaller = new EventEmitter();
+      var handshakeID = hat();
+      var rpc = new RPC({ nick: 'a', wrtc: wrtc, signaller: signaller });
+      var neighbor = new SimplePeer({ wrtc: wrtc, initiator: true });
+      neighbor.on('signal', function(signal) {
+        var message = { signal: signal, handshakeID: handshakeID, sender: 'b' };
+        rpc._onSignal(message);
+        var peerCount = Object.keys(rpc._peers).length;
+        expect(peerCount).to.equal(1);
+        neighbor.destroy();
+        done();
+      });
+    });
+
+    it('should signal a new peer', function() {
+      var signaller = new EventEmitter();
+      var handshakeID = hat();
+      var rpc = new RPC({ nick: 'a', wrtc: wrtc, signaller: signaller });
+      var signalStub = sinon.stub();
+      sinon.stub(rpc, '_createPeer', function() {
+        return { once: sinon.stub(), signal: signalStub };
+      });
+      rpc._onSignal({ signal: 'test', handshakeID: handshakeID, sender: 'b' });
+      expect(signalStub.calledWith('test')).to.equal(true);
+    });
+
+    it('should signal an existing peer', function() {
+      var signaller = new EventEmitter();
+      var handshakeID = hat();
+      var rpc = new RPC({ nick: 'a', wrtc: wrtc, signaller: signaller });
+      rpc._createPeer('a', handshakeID, true);
+      var peer = rpc._peers[handshakeID];
+      var signalStub = sinon.stub(peer, 'signal');
+      var signal = '';
+      rpc._onSignal({ signal: signal, handshakeID: handshakeID, sender: 'b' });
+      expect(signalStub.calledWith(signal)).to.equal(true);
+    });
+  });
+
+  describe('#_createPeer', function() {
+
+    it("should forward the peer's signals to the signaller", function(done) {
+      var signaller = new EventEmitter();
+      var rpc = new RPC({ nick: 'a', wrtc: wrtc, signaller: signaller });
+      var handshakeID = hat();
+      var peer = rpc._createPeer('b', handshakeID, true);
+      signaller.once('b', function(message) {
+        expect(message.sender).to.equal('a');
+        expect(message.handshakeID).to.equal(handshakeID);
+        done();
+      });
+    });
+
+    it("should log the peer's errors", function() {
+      var signaller = new EventEmitter();
+      var rpc = new RPC({ nick: 'a', wrtc: wrtc, signaller: signaller });
+      var handshakeID = hat();
+      var peer = rpc._createPeer('b', handshakeID, true);
+      var error = sinon.stub(rpc._log, 'error');
+      peer.signal('bad signal');
+      var ok = error.calledWith(
+        'peer encountered an error %s',
+        'signal() called with invalid signal data');
+      expect(ok).to.equal(true);
+    });
+
+    it("should remove the peer's listeners when closed", function() {
+      var signaller = new EventEmitter();
+      var rpc = new RPC({ nick: 'a', wrtc: wrtc, signaller: signaller });
+      var handshakeID = hat();
+      var peer = rpc._createPeer('b', handshakeID, true);
+
+      // Set up some event listeners
+      peer.on('data', expect.fail);
+      peer.on('signal', expect.fail);
+      peer.on('error', expect.fail);
+
+      // This should remove the event listeners
+      peer.emit('close');
+
+      // Make sure the event listeners are removed
+      peer.emit('data');
+      peer.emit('signal');
+
+      // If error has no event listeners, EventEmitter will throw.
+      // So let's just add a stub.
+      peer.on('error', sinon.stub());
+      peer.emit('error');
+    });
+
+    it('should add the peer to the collection', function() {
+      var signaller = new EventEmitter();
+      var rpc = new RPC({ nick: 'a', wrtc: wrtc, signaller: signaller });
+      var handshakeID = hat();
+      var peer = rpc._createPeer('b', handshakeID, true);
+      expect(rpc._peers[handshakeID]).to.equal(peer);
+    });
+  });
+
+  describe('#_createContact', function() {
+    it('should create a WebRTCContact', function() {
+      var signaller = new EventEmitter();
+      var rpc = new RPC({ nick: 'a', wrtc: wrtc, signaller: signaller });
+      var contact = rpc._createContact({ nick: 'b' });
+      expect(contact).to.be.instanceOf(WebRTCContact);
+    });
+  });
+
+  describe('#send', function() {
+
+    var rpc1;
+    var rpc2;
+
+    before(function() {
+      var signaller = new EventEmitter();
+      rpc1 = new RPC({ nick: 'a', wrtc: wrtc, signaller: signaller });
+      rpc2 = new RPC({ nick: 'b', wrtc: wrtc, signaller: signaller });
+    });
+
+    after(function() {
+      rpc1.close();
+      rpc2.close();
+    });
+
+    it('should throw with invalid contact', function() {
+      expect(function() {
+        rpc1.send(25);
+      }).to.throw(Error, 'Invalid contact supplied');
+    });
+
+    it('should throw with invalid message', function() {
+      var contact = new WebRTCContact({ nick: 'b' });
+      expect(function() {
+        rpc1.send(contact, {});
+      }).to.throw(Error, 'Invalid message supplied');
+    });
+
+    it('should send a message and create a response handler', function() {
+      var addr1 = rpc1._contact;
+      var addr2 = rpc2._contact;
+      var contactRpc1 = new WebRTCContact(addr1);
+      var contactRpc2 = new WebRTCContact(addr2);
+      var msg = new Message('PING', {}, contactRpc1);
+      var handler = sinon.stub();
+      rpc1.send(contactRpc2, msg, handler);
+      var calls = Object.keys(rpc1._pendingCalls);
+      expect(calls).to.have.lengthOf(1);
+      expect(rpc1._pendingCalls[calls[0]].callback).to.equal(handler);
+    });
+
+    it('should send a message and forget it', function() {
+      var addr1 = rpc1._contact;
+      var addr2 = rpc2._contact;
+      var contactRpc1 = new WebRTCContact(addr1);
+      var contactRpc2 = new WebRTCContact(addr2);
+      var msg = new Message('PING', {}, contactRpc1);
+      rpc2.send(contactRpc1, msg);
+      var calls = Object.keys(rpc2._pendingCalls);
+      expect(calls).to.have.lengthOf(0);
+    });
+
+    it('should transmit a message', function(done) {
+      var signaller = new EventEmitter();
+      var rpc1 = new RPC({ nick: 'a', wrtc: wrtc, signaller: signaller });
+      var rpc2 = new RPC({ nick: 'b', wrtc: wrtc, signaller: signaller });
+      var message = new Message('PING', {}, rpc2._contact);
+      rpc1.once('PING', function() {
+        done();
+      });
+      rpc2._send(message.serialize(), rpc1._contact);
+    });
+  });
+
+  describe('#close', function() {
+
+    it('should destroy the underlying peers', function() {
+      var signaller = new EventEmitter();
+      var handshakeID = hat();
+      var rpc = new RPC({ nick: 'a', wrtc: wrtc, signaller: signaller });
+      rpc._createPeer('a', handshakeID, true);
+      var peer = rpc._peers[handshakeID];
+      var destroy = sinon.stub(peer, 'destroy');
+      rpc.close();
+      expect(destroy.callCount).to.equal(1);
+      expect(rpc._peers).to.deep.equal({});
+    });
+
+    it('should unsusbcribe from the signaller', function() {
+      var signaller = new EventEmitter();
+      var handshakeID = hat();
+      var rpc = new RPC({ nick: 'a', wrtc: wrtc, signaller: signaller });
+      var removeListener = sinon.stub(signaller, 'removeListener');
+      rpc._createPeer('a', handshakeID, true);
+      rpc.close();
+      expect(removeListener.callCount).to.equal(1);
+      expect(removeListener.calledWith('a', rpc._signalHandler)).to.equal(true);
+    });
+  });
+
+  describe('#_handleMessage', function() {
+
+    var contact1 = new WebRTCContact({ nick: 'a' });
+    var validMsg1 = Message('PING', { rpcID: 10 }, contact1).serialize();
+    var validMsg2 = Message('PONG', { referenceID: 10 }, contact1).serialize();
+    var invalidMsg = Buffer(JSON.stringify({ type: 'WRONG', params: {} }));
+    var invalidJSON = Buffer('i am a bad message');
+    var rpc = new RPC({ nick: 'b', wrtc: wrtc, signaller: new EventEmitter() });
+
+    it('should drop the message if invalid JSON', function(done) {
+      rpc.once('MESSAGE_DROP', function() {
+        done();
+      });
+      rpc._handleMessage(invalidJSON, {});
+    });
+
+    it('should drop the message if invalid message type', function(done) {
+      rpc.once('MESSAGE_DROP', function() {
+        done();
+      });
+      rpc._handleMessage(invalidMsg, {});
+    });
+
+    it('should emit the message type if not a reply', function(done) {
+      rpc.once('PING', function(data) {
+        expect(typeof data).to.equal('object');
+        done();
+      });
+      rpc._handleMessage(validMsg1, { address: '127.0.0.1', port: 1234 });
+    });
+
+    it('should call the message callback if a reply', function(done) {
+      rpc._pendingCalls[10] = {
+        callback: function(err, params) {
+          expect(err).to.equal(null);
+          expect(params.referenceID).to.equal(10);
+          done();
+        }
+      }
+      rpc._handleMessage(validMsg2, { address: '127.0.0.1', port: 1234 });
+    });
+
+  });
+
+  describe('#_expireCalls', function() {
+
+    it('should call expired handler with error and remove it', function() {
+      var signaller = new EventEmitter();
+      var rpc = new RPC({ nick: 'a', wrtc: wrtc, signaller: signaller });
+      var freshHandler = sinon.stub();
+      var staleHandler = sinon.spy();
+      rpc._pendingCalls['rpc_id_1'] = {
+        timestamp: new Date('1970-1-1'),
+        callback: staleHandler
+      };
+      rpc._pendingCalls['rpc_id_2'] = {
+        timestamp: new Date('3070-1-1'),
+        callback: freshHandler
+      };
+      rpc._expireCalls();
+      expect(Object.keys(rpc._pendingCalls)).to.have.lengthOf(1);
+      expect(freshHandler.callCount).to.equal(0);
+      expect(staleHandler.callCount).to.equal(1);
+      expect(staleHandler.getCall(0).args[0]).to.be.instanceOf(Error);
+    });
+
+  });
+
+  describe('#_close', function() {
+
+    it('should clean up the peers', function() {
+      var signaller = new EventEmitter();
+      var rpc = new RPC({ nick: 'a', wrtc: wrtc, signaller: signaller });
+      var peer = rpc._createPeer();
+      rpc._close();
+      expect(peer.destroyed).to.equal(true);
+      expect(rpc._peers).to.deep.equal({});
+    });
+
+    it('should unsusbcribe from the signaller', function() {
+      var signaller = new EventEmitter();
+      var rpc = new RPC({ nick: 'a', wrtc: wrtc, signaller: signaller });
+      var removeListener = sinon.stub(signaller, 'removeListener');
+      rpc._close();
+      expect(removeListener.calledWith('a', rpc._signalHandler)).to.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
Continuing the conversation from [here](https://github.com/omphalos/kad/commit/8de7a4fe4fceb9ccc8f91c8adc6b72e94b975407#commitcomment-13023964).

> Personally, I'm not fond of the places where I see this.Contact = .... It feels less than idiomatic to assign a constructor as a member of an instance. Perhaps we could avoid this.

Yeah, I agree with you.  I'm thinking just a `createContact` function on the transport would be better.

> Right now the Transport._send method takes a port, address. Maybe it would be better to pass it a contact instead and let the transport handle checking if it's the right type of contact.

Good point.

> Another option is to leave Contact with IP and port and use the PeerJS server for those values and simply overload the method that assigns the nodeID.

I think that's a good suggestion and would simplify things a bit.